### PR TITLE
修复按钮和编辑框宽度

### DIFF
--- a/ftpServer.py
+++ b/ftpServer.py
@@ -739,7 +739,7 @@ def main():
         family="Consolas", size=font.nametofont("TkTextFont").cget("size")
     )
     style = ttk.Style(window)
-    style.configure("TButton", width=7, padding=(scale(5), scale(2)))
+    style.configure("TButton", width=-5, padding=(scale(8), scale(2)))
     style.configure("TEntry", padding=(scale(2), scale(3)))
     style.configure("TCombobox", padding=(scale(2), scale(3)))
     window.geometry(f"{scale(600)}x{scale(500)}")
@@ -770,24 +770,22 @@ def main():
         side=tk.LEFT, padx=(0, scale(10))
     )
 
-    ttk.Button(frame1, text="选择目录", command=pickDirectory, width=8).pack(
+    ttk.Button(frame1, text="选择目录", command=pickDirectory).pack(
         side=tk.LEFT, padx=(0, scale(10))
     )
 
     directoryCombobox = ttk.Combobox(frame1, width=0)
     directoryCombobox.pack(side=tk.LEFT, fill=tk.X, expand=True)
 
-    ttk.Button(
-        frame1, text="X", command=deleteCurrentComboboxItem, width=0
-    ).pack(side=tk.LEFT, padx=(0, scale(10)), ipadx=5)
-
-    ttk.Button(frame1, text="帮助", command=showHelp).pack(
+    ttk.Button(frame1, text="X", command=deleteCurrentComboboxItem, width=0).pack(
         side=tk.LEFT, padx=(0, scale(10))
     )
 
-    ttk.Button(frame1, text="关于", command=showAbout).pack(
-        side=tk.LEFT, padx=(0, scale(10))
+    ttk.Button(frame1, text="帮助", command=showHelp, width=-4).pack(
+        side=tk.LEFT, padx=(0, scale(5))
     )
+
+    ttk.Button(frame1, text="关于", command=showAbout, width=-4).pack(side=tk.LEFT)
 
     frame2 = ttk.Frame(window)
     frame2.pack(fill=tk.X, padx=scale(10), pady=(0, scale(10)))
@@ -799,13 +797,13 @@ def main():
         row=0, column=0, pady=(0, scale(5)), padx=(0, scale(5))
     )
     userNameVar = tk.StringVar()
-    userNameEntry = ttk.Entry(userFrame, textvariable=userNameVar, width=scale(12))
+    userNameEntry = ttk.Entry(userFrame, textvariable=userNameVar, width=20)
     userNameEntry.grid(row=0, column=1, sticky=tk.EW, pady=(0, scale(5)))
 
     ttk.Label(userFrame, text="密码").grid(row=1, column=0, padx=(0, scale(5)))
     userPasswordVar = tk.StringVar()
     userPasswordEntry = ttk.Entry(
-        userFrame, textvariable=userPasswordVar, width=scale(12), show="*"
+        userFrame, textvariable=userPasswordVar, width=20, show="*"
     )
     userPasswordEntry.grid(row=1, column=1, sticky=tk.EW)
 


### PR DESCRIPTION
非常抱歉，由于我的疏忽，导致 #24 中存在几个bug：

- 用户编辑框宽度不正确（因为我直接将 `place` 中的 `width` 移动到 `Entry` 中，但忘记了移除 `scale` 函数，导致了 bug）
- 开启/关闭按钮偏大
- 帮助/关于按钮过大
- 帮助/关于按钮间距偏大
- 选择目录按钮过小

现在这个 pr 修复了以上问题。

<img width="604" height="274" alt="image" src="https://github.com/user-attachments/assets/d9906f4e-e701-4f2b-b587-fcbb30b11895" />

但是按钮高度和 v1.23 的高度在 100% 缩放下仍然不一样，但在 125% 和 150% 缩放下是差不多的：

<img width="1203" height="487" alt="image" src="https://github.com/user-attachments/assets/50e69917-edcd-40d2-897f-4fbe04419977" />

但是我感觉 v1.23 在 100% 缩放下的高度有一点小，所以我没有解决此问题。
