### PR TITLE
修复dpi感知不正确

### DIFF
--- a/ftpServer.py
+++ b/ftpServer.py
@@ -727,7 +727,7 @@ def main():
     global isAutoStartServerVar
 
     # 告诉操作系统使用程序自身的dpi适配
-    ctypes.windll.shcore.SetProcessDpiAwareness(2)
+    ctypes.windll.shcore.SetProcessDpiAwareness(1) # PROCESS_SYSTEM_DPI_AWARE
 
     mystd = myStdout()  # 实例化重定向类
     logThread = threading.Thread(target=logThreadFun)


### PR DESCRIPTION
原先代码中使用 `PROCESS_PER_MONITOR_DPI_AWARE`，这需要软件自己处理缩放变更的情况。但是在tkinter中很难自行处理，并且pystray和窗口标题栏也有问题，所以我改为了 `PROCESS_SYSTEM_DPI_AWARE`，在缩放率变更时让系统自己处理。

这不会导致在非100%缩放的模糊，因为在启动时，缩放仍然由软件自行处理。

## 文档

https://learn.microsoft.com/zh-cn/windows/win32/api/shellscalingapi/nf-shellscalingapi-setprocessdpiawareness