### PR TITLE
剔除pywin32，提升软件的健壮性

### DIFF
--- a/ftpServer.py
+++ b/ftpServer.py
@@ -723,7 +723,8 @@ def main():
     global isAutoStartServerVar
 
     # 告诉操作系统使用程序自身的dpi适配
-    ctypes.windll.shcore.SetProcessDpiAwareness(2)
+    if sys.platform == 'win32' and  hasattr(ctypes.windll.shcore, "SetProcessDpiAwareness"):
+        ctypes.windll.shcore.SetProcessDpiAwareness(2)
 
     mystd = myStdout()  # 实例化重定向类
     logThread = threading.Thread(target=logThreadFun)


### PR DESCRIPTION
tkinter已经自带剪贴板操作的api了，因此没必要使用pywin32。

仅在win32平台调用 `ctypes.windll.shcore` 和 `SetProcessDpiAwareness`，提升软件的健壮性，更有利于后期将软件移植到其他平台（如果有的话）（与 #27 冲突，合并前需要解决）。

此pr只是提升软件的健壮性，并没有完全解决跨平台问题。要真的在linux运行的话，还需要 f7f5c7917ed146a844201a4fd7b8763163e59402 （linux中会额外调用io的其他方法，因此需要此提交），还要解决pystray的依赖问题。

## linux成功运行的截图

<img width="598" height="591" alt="Snipaste_2025-11-06_16-00-12" src="https://github.com/user-attachments/assets/aabaff3a-bd31-4e21-921d-dfe1c0934e8f" />
